### PR TITLE
Fix: Prevent hang when TMDB auto-match fails

### DIFF
--- a/src/lib/server/trackers/aither.ts
+++ b/src/lib/server/trackers/aither.ts
@@ -182,7 +182,7 @@ export default class Aither extends Tracker {
         this.data.imdb = metadata.imdbId ? metadata.imdbId.replace(/^tt/i, '') : '0';
         this.data.tvdb = metadata.tvdbId ? String(metadata.tvdbId) : '0';
         this.data.mal = metadata.malId ? String(metadata.malId) : '0';
-        this.data.keywords = metadata.keywords.join(', ');
+        this.data.keywords = (metadata.keywords || []).join(', ');
     }
 
     applyRelease(release: Release) {

--- a/src/lib/server/trackers/lst.ts
+++ b/src/lib/server/trackers/lst.ts
@@ -223,7 +223,7 @@ export default class LST extends Tracker {
         this.data.imdb = metadata.imdbId ? metadata.imdbId.replace(/^tt/i, '') : '0';
         this.data.tvdb = metadata.tvdbId ? String(metadata.tvdbId) : '0';
         this.data.mal = metadata.malId ? String(metadata.malId) : '0';
-        this.data.keywords = metadata.keywords.join(', ');
+        this.data.keywords = (metadata.keywords || []).join(', ');
     }
 
     applyRelease(release: Release) {

--- a/src/lib/server/trackers/midnightscene.ts
+++ b/src/lib/server/trackers/midnightscene.ts
@@ -127,7 +127,7 @@ export default class MidnightScene extends Tracker {
         this.data.imdb = metadata.imdbId ? metadata.imdbId.replace(/^tt/i, '') : '0';
         this.data.tvdb = metadata.tvdbId ? String(metadata.tvdbId) : '0';
         this.data.mal = metadata.malId ? String(metadata.malId) : '0';
-        this.data.keywords = metadata.keywords.join(', ');
+        this.data.keywords = (metadata.keywords || []).join(', ');
     }
 
     applyRelease(release: Release) {

--- a/src/lib/server/trackers/seedpool.ts
+++ b/src/lib/server/trackers/seedpool.ts
@@ -155,7 +155,7 @@ export default class Seedpool extends Tracker {
         this.data.imdb = metadata.imdbId ? metadata.imdbId.replace(/^tt/i, '') : '0';
         this.data.tvdb = metadata.tvdbId ? String(metadata.tvdbId) : '0';
         this.data.mal = metadata.malId ? String(metadata.malId) : '0';
-        this.data.keywords = metadata.keywords.join(', ');
+        this.data.keywords = (metadata.keywords || []).join(', ');
     }
 
     applyRelease(release: Release) {

--- a/src/lib/server/upload.ts
+++ b/src/lib/server/upload.ts
@@ -6,7 +6,7 @@ import Files, { type FilesState } from './files';
 import Torrent from './torrent';
 import Screenshots from './screenshots';
 import getMediaInfo from '$lib/server/mediainfo';
-import type { TmdbHydratedSearchResult, TrackerFieldsState, TrackersAfterUploadActionsState, TrackerSearchResults, TrackerSearchResultState, TrackerState, TrackerStatus, TrackerStatusState } from '$lib/types';
+import type { TmdbHydratedSearchResult, TrackerFieldsState, TrackersAfterUploadActionsState, TrackerSearchResults, TrackerSearchResultState, TrackerState, TrackerStatus, TrackerStatusState, Metadata } from '$lib/types';
 import { Trackers } from './trackers';
 import { normalize } from './util/normalize';
 import { getMalId } from './jikan';
@@ -187,12 +187,17 @@ export default class Upload {
             if (results.match) {
                 await this.selectTmdbResult(results.match.result.tmdbId, results.match.name);
                 this.signal.throwIfAborted();
+            } else {
+                // No auto-match found, set empty metadata to unblock workflow
+                this.setEmptyMetadata();
             }
 
 
         } catch (error) {
             this.errors.push(errorString('Problem with TMDB', error));
             this.emitUpdate('errors');
+            // Even on error, unblock workflow with empty metadata
+            this.setEmptyMetadata();
         }
 
     }
@@ -241,6 +246,36 @@ export default class Upload {
 
     onUpdate(callback: (callback: Partial<UploadState>) => void) {
         this.updateCallbacks.push(callback);
+    }
+
+    // ADDED THIS NEW METHOD:
+    private async setEmptyMetadata() {
+        // Set minimal metadata to unblock the "Ready to edit" status
+        // when TMDB auto-match fails or errors occur
+        const emptyMetadata: Metadata = {
+            malId: null,
+            originCountry: null,
+            originalLanguage: '',
+            originalTitle: '',
+            overview: '',
+            year: this.release.year,
+            title: this.release.title,
+            genres: [],
+            posterUrl: null,
+            tmdbId: 0,
+            imdbId: null,
+            tvdbId: null,
+            keywords: [],
+        };
+
+        // Wait for MediaInfo before setting metadata
+        if (this.mediaInfo) await this.mediaInfo;
+        this.signal.throwIfAborted();
+
+        if (this.trackers) {
+            this.trackers.setMetadata(emptyMetadata);
+            // Don't search for duplicates without real TMDB data
+        }
     }
 
     async selectTmdbResult(id: number, matchedTitle?: string) {


### PR DESCRIPTION
## Problem
Uploads get stuck indefinitely at status "⏳ Waiting for MediaInfo and metadata" when TMDB cannot auto-match the release. This happens because:
- MediaInfo completes successfully
- TMDB search runs but finds no confident match
- `setMetadata()` is never called
- Tracker status never transitions to "✏️ Ready to edit"

## Solution
When TMDB auto-match fails or errors occur, set empty/minimal metadata to unblock the workflow. Users can then manually select from TMDB results or enter IDs in the tracker forms.

## Changes
1. **upload.ts**: Added `setEmptyMetadata()` method that creates minimal metadata object
2. **upload.ts**: Updated `initializeTmdb()` to call `setEmptyMetadata()` when no match found or on error
3. **All trackers**: Fixed `applyMetadata()` to safely handle empty keywords array

## Testing
- [x] Tested with file that has no TMDB match - workflow proceeds to edit phase
- [x] Verified manual TMDB selection works after empty metadata is set
- [x] Confirmed existing auto-match flow is not affected

## Benefits
✅ No more indefinite hangs on TMDB failures  
✅ Users can proceed and manually enter TMDB info  
✅ All existing functionality preserved  
✅ Defensive coding prevents crashes 

- Add setEmptyMetadata() to unblock workflow when no TMDB match found
- Call setEmptyMetadata() on TMDB errors to prevent indefinite hang
- Fix applyMetadata() in all trackers to handle empty keywords array
- Allow users to manually enter TMDB info and continue upload process

Fixes issue where uploads get stuck at 'Waiting for MediaInfo and metadata' when TMDB cannot auto-match the release.