### PR TITLE
fix(tracker): add season/episode filtering to seedpool search

### DIFF
--- a/src/lib/server/trackers/seedpool.ts
+++ b/src/lib/server/trackers/seedpool.ts
@@ -229,6 +229,9 @@ export default class Seedpool extends Tracker {
         params.append('resolutions[]', this.data.resolutionId);
         params.append('types[]', this.data.typeId);
 
+        if (this.data.seasonNumber) params.append('seasonNumber', this.data.seasonNumber);
+        if (this.data.episodeNumber) params.append('episodeNumber', this.data.episodeNumber);
+
         const response = await fetch(url, { headers: this.headers });
         const data = await response.json();
         const validated = v.parse(SearchResultsSchema, data).data;


### PR DESCRIPTION
Seedpool's duplicate search is not filtering by season or episode. Duplicate detection may not yield the expected results for TV and anime uploads.

Adds `seasonNumber` and `episodeNumber` query parameters to the Seedpool `search()` method, matching the LST and Aither modules. This should help narrow the search and provide more relevant results.